### PR TITLE
Add LLM resources, agent workflow, and WCAG AA fixes

### DIFF
--- a/.cursor/rules/canonical-rules.mdc
+++ b/.cursor/rules/canonical-rules.mdc
@@ -1,0 +1,15 @@
+---
+alwaysApply: true
+---
+
+# Canonical project rules
+
+**[CLAUDE.md](CLAUDE.md) is the single source of truth** for conventions, workflow, WCAG AA accessibility, LLM file sync, and agent behaviour in this repo.
+
+Before editing code or content:
+
+1. Read @CLAUDE.md if it is not already in context
+2. Follow its rules — especially WCAG AA, coding conventions, and keeping `index.html.md` / `llms.txt` in sync with `index.html`
+3. Treat [README.md](README.md) as human onboarding only; do not treat it as overriding CLAUDE.md
+
+When guidance conflicts, **CLAUDE.md wins**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,197 @@
+# CLAUDE.md
+
+Canonical rulebook for Claude Code working in this repository. For onboarding and feature detail, see [README.md](README.md).
+
+## Project overview
+
+Personal PM portfolio — single-page static site hosted on GitHub Pages at `https://trstndvll.github.io` / `https://www.trstndvll.com`.
+
+## Tech stack
+
+| Layer | Technology |
+|-------|------------|
+| Structure | HTML5 (`index.html`) |
+| Styles | CSS3 — no framework (`css/styles.css`) |
+| Scripts | Vanilla JS — inline in `index.html` |
+| Fonts | Google Fonts — DM Sans, DM Serif Display |
+| Forms | [Formspree](https://formspree.io/) |
+| Spam protection | reCAPTCHA v2 |
+| Analytics | Google Analytics (gtag) |
+| Hosting | GitHub Pages + custom domain via `CNAME` |
+
+**No Node, no bundler, no package manager, no build step.**
+
+## Directory structure
+
+| Path | Purpose |
+|------|---------|
+| `index.html` | Entire site: structure, content, inline SVGs, inline JS |
+| `css/styles.css` | All styles; CSS custom properties, responsive breakpoints |
+| `images/` | Static assets — `tristan.png`, `favicon.png`, `opengraph.png` |
+| `llms.txt` | LLM-oriented site summary per [llms.txt spec](https://llmstxt.org/) — served at `/llms.txt` |
+| `index.html.md` | Full markdown mirror of `index.html` — served at `/index.html.md` |
+| `sitemap.xml` | XML sitemap for search engines — served at `/sitemap.xml`; lists all crawlable URLs |
+| `robots.txt` | Crawler directives — served at `/robots.txt`; points to `sitemap.xml` |
+| `CNAME` | Custom domain (`www.trstndvll.com`) |
+| `README.md` | Human-facing intro, local dev, deployment |
+| `.gitignore` | Ignores `.DS_Store` |
+
+## Accessibility — WCAG AA
+
+**Standard:** This site targets **WCAG 2.x Level AA**. Treat AA as a hard constraint — not a nice-to-have.
+
+**Colour contrast**
+- Normal text: **4.5:1** minimum
+- Large text / UI components: **3:1** minimum
+- Use AA-safe tokens instead of one-off hex values:
+  - `--blue-dark` — text/buttons on light backgrounds
+  - `--muted-on-dark` — placeholder/footer text on dark backgrounds (`#contact`)
+
+**CSS fix comments**
+- Existing AA fixes use `/* WCAG AA fix — was: … */` in `css/styles.css` — preserve when editing
+- Add the same comment pattern when adjusting colours for contrast
+
+**HTML patterns (already in use)**
+- Decorative SVGs: `aria-hidden="true"`
+- Interactive controls: `aria-label`, `aria-expanded`, `aria-live`
+- Content images: meaningful `alt` text; decorative tool icons: `alt=""`
+- Form reCAPTCHA hidden until fields filled; `aria-hidden` toggled with visibility
+- `scroll-margin-top: 56px` on sections so anchor nav doesn't hide headings
+
+**Keyboard**
+- Hamburger menu, form submit, and `<details>` case-study summaries must work without a mouse
+- New interactive elements need visible focus states
+
+**Rule:** Any colour or interactive change must not regress AA compliance.
+
+## Coding conventions
+
+### HTML
+
+- 2-space indent; `lang="en-CA"`
+- Section markers: `<!-- NAV -->`, `<!-- HERO -->`, etc.
+- Anchor-based single-page nav (`#about`, `#skills`, `#case-studies`, …)
+- Inline Feather-style SVG icons on nav and section titles
+- Semantic layout: `<section id="…">` → `.container` wrapper
+- Case studies: native `<details>/<summary>` (not JS accordion)
+- Copy: Canadian English
+
+### CSS
+
+- Single file: `css/styles.css`
+- Section headers: `/* ── SECTION NAME ── */`
+- Design tokens in `:root` — **always use variables**, not hardcoded colours
+- Class naming: kebab-case; BEM-style modifiers (`form-recaptcha--hidden`)
+- Card pattern: white bg, `border: 1px solid var(--border)`, `border-radius: var(--radius)`
+- Typography: DM Sans (body/UI), DM Serif Display (hero, contact, case study titles)
+- Responsive breakpoints: `1024px` (nav → hamburger), `640px` (grid collapse)
+
+### JavaScript
+
+- Inline `<script>` at bottom of `index.html` — no separate JS file today
+- DOM queries by ID, event listeners, async `fetch` to Formspree
+- reCAPTCHA shown only after all form fields filled (`updateRecaptchaVisibility`)
+
+### Assets
+
+- Images live in `images/`
+- Mixed path style today:
+  - Favicon / OG meta: absolute `/images/…` or full `https://www.trstndvll.com/images/…`
+  - Content images: relative `images/tristan.png`
+
+### Third-party keys
+
+Formspree endpoint, reCAPTCHA site key, and GA ID are committed in HTML. These are public client-side keys — acceptable for these services.
+
+## LLM-friendly files
+
+This site follows the [llms.txt](https://llmstxt.org/) convention for LLM-readable content:
+
+- **`llms.txt`** — curated summary: elevator pitch, distilled skills/experience/case studies, links to site sections and profiles. Linked from the site footer (`LLM resources`).
+- **`index.html.md`** — full-fidelity markdown of all page content for LLMs that need detail beyond the summary.
+
+Both are static files at repo root; GitHub Pages serves them with no build step.
+
+## Sitemap
+
+`sitemap.xml` lists every **standalone, crawlable URL** on the site (canonical domain `https://www.trstndvll.com`). `robots.txt` references it via a `Sitemap:` directive.
+
+**Currently listed:** `/`, `/llms.txt`, `/index.html.md`.
+
+**Do not list** in-page section anchors (`#about`, `#skills`, …) — search engines treat the portfolio as a single page at `/`. Section URLs belong in `llms.txt` (`## Site sections`), not in the sitemap.
+
+**When adding a new page** (new HTML file, or any new root-level resource served as its own URL): add a `<url>` block to `sitemap.xml` with `<loc>`, `<lastmod>` (ISO date), and appropriate `<changefreq>` / `<priority>`. Bump `<lastmod>` on existing entries when those files change materially.
+
+## Run, test, build, deploy
+
+| Action | Command |
+|--------|---------|
+| Local preview (recommended) | `python3 -m http.server 8000` → `http://localhost:8000` |
+| Local preview (quick) | Open `index.html` in browser |
+| Build | None |
+| Test | None — manual browser check |
+| Deploy | Commit + push to `main`; GitHub Pages rebuilds in ~1–2 min |
+
+See [README.md](README.md) for step-by-step local dev and deployment instructions.
+
+## Rules for Claude
+
+### Always
+
+- Keep changes minimal and scoped to the request
+- Match existing HTML/CSS patterns (tokens, class names, section structure)
+- **Maintain WCAG AA compliance** — do not regress contrast, keyboard access, or screen-reader support
+- Use AA-safe tokens (`--blue-dark`, `--muted-on-dark`) instead of lighter/darker one-offs
+- Add `/* WCAG AA fix */` comments when adjusting colours for contrast
+- Preserve `aria-*` attributes, alt text, focus states, and `aria-live` feedback patterns
+- Test locally with HTTP server before considering done
+- Use Canadian English in copy edits
+- When editing portfolio copy or structure in `index.html`, update `index.html.md` and `llms.txt` in the same pass — do not leave them stale
+- After any content/structure edit: spot-check `llms.txt` and `index.html.md` reflect the same facts and section anchors as `index.html`
+- When adding a new crawlable page or materially updating an existing one, update `sitemap.xml` (`<lastmod>` at minimum; new `<url>` entry for new pages)
+
+### Never
+
+- Introduce colour combinations that fail WCAG AA contrast
+- Remove or weaken existing accessibility attributes to simplify markup
+- Introduce frameworks (React, Tailwind, etc.) or build tooling without explicit request
+- Split into multiple pages or add routing without explicit request
+- Commit secrets that aren't already public client-side keys
+- Create commits or push unless explicitly asked
+- Duplicate README content into this file
+
+### When editing content
+
+- Hero, experience, case studies, skills: all inline in `index.html`
+- New case study: copy existing `<details class="case-study">` structure (Context → Problem → Role → Decisions → Execution → Outcome)
+- New nav item: add to both `.nav-links` and `.mobile-menu` with matching SVG icon
+- **Keep LLM files in sync:** Any change to portfolio **content** or **structure** in `index.html` must also update `index.html.md` and `llms.txt` in the same change (or immediately follow-up commit)
+- **`index.html.md`:** Mirror all copy changes — hero, about, skills, case studies, experience, volunteering, education, contact, footer. Match section order and headings to `index.html`
+- **`llms.txt`:** Update the distilled body (skills, experience table, case study summaries, contact) and the `## Site sections` link list when sections are added, renamed, or removed. Keep the summary concise; do not paste full case study bodies here
+- **New nav section:** Add anchor to both `.nav-links` / `.mobile-menu` in `index.html`, a matching section in `index.html.md`, an entry under `## Site sections` in `llms.txt`
+- **New case study:** Add full `<details>` block in `index.html`, full section in `index.html.md`, one-line summary in `llms.txt` case studies list
+- **New standalone page** (e.g. new `.html` or served static file at repo root): add a `<url>` entry in `sitemap.xml`; update `llms.txt` / `index.html.md` only if content belongs there
+- **Homepage content change:** bump `<lastmod>` on the `/` entry in `sitemap.xml` when portfolio copy or structure changes
+
+### When editing styles
+
+- Add to `css/styles.css` in the appropriate section
+- Use existing CSS variables; add new tokens to `:root` if needed
+- Update responsive rules in the `@media` blocks at file bottom
+
+## [SUGGESTED] conventions
+
+Not yet enforced — review and accept/reject before treating as canonical.
+
+- **[SUGGESTED] Commit messages:** Imperative, sentence-case (e.g. `Add volunteer section`, `Fix case study mobile padding`). Avoid kebab-case (`update-hero`).
+- **[SUGGESTED] External links:** Always add `rel="noopener noreferrer"` on `target="_blank"` links (currently inconsistent).
+- **[SUGGESTED] Image paths:** Standardize on relative `images/…` for portability; reserve absolute URLs for OG/Twitter meta only.
+- **[SUGGESTED] JS extraction:** If JS grows beyond ~80 lines, move to `js/main.js` — not needed today.
+- **[SUGGESTED] Pre-deploy checklist:** Nav (desktop + mobile), case study expand/collapse, contact form + reCAPTCHA, responsive at 640px/1024px, **WCAG AA contrast spot-check** on any changed colours (browser DevTools or [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)).
+- **[SUGGESTED] Tooling:** Do not add ESLint/Prettier/CI unless the project grows significantly.
+
+## Where README is the better reference
+
+- Clone and setup instructions
+- High-level architecture description
+- Formspree and reCAPTCHA service explanations

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ The layout is optimized for readability on both desktop and mobile and is intend
 
 ---
 
+### AI agent resources
+
+| Resource | Purpose |
+|----------|---------|
+| [CLAUDE.md](CLAUDE.md) | **Canonical rulebook** — coding conventions, WCAG AA, workflow, LLM file sync, and rules for AI agents working in this repo |
+| [.cursor/rules/](.cursor/rules/) | **Cursor project rules** — always-applied instructions that point Agent at [CLAUDE.md](CLAUDE.md) as the source of truth ([Cursor rules docs](https://cursor.com/docs/rules)) |
+
+Use CLAUDE.md when working with Claude Code or any AI assistant editing this codebase. Cursor loads `.cursor/rules/canonical-rules.mdc` automatically in every Agent session.
+
+---
+
 ### Tech Stack
 
 - **Frontend**: Plain HTML, CSS, and minimal JavaScript.
@@ -32,6 +43,30 @@ The layout is optimized for readability on both desktop and mobile and is intend
   - [reCAPTCHA v2](https://www.google.com/recaptcha/about/) — "I'm not a robot" checkbox to reduce spam.
 - **Hosting**:
   - [GitHub Pages](https://pages.github.com/) from the `trstndvll.github.io` repository.
+
+---
+
+### LLM-friendly files
+
+This site follows the [llms.txt](https://llmstxt.org/) convention for LLM-readable content:
+
+| File | URL | Purpose |
+|------|-----|---------|
+| `llms.txt` | `https://www.trstndvll.com/llms.txt` | Curated summary for LLMs |
+| `index.html.md` | `https://www.trstndvll.com/index.html.md` | Full markdown mirror of the portfolio page |
+
+**When updating site content** (hero, case studies, experience, skills, nav sections, contact, etc.), update both files so they stay in sync with `index.html`. See [CLAUDE.md](CLAUDE.md) for the full sync checklist.
+
+---
+
+### SEO & discovery
+
+| File | URL | Purpose |
+|------|-----|---------|
+| `sitemap.xml` | `https://www.trstndvll.com/sitemap.xml` | XML sitemap — lists all crawlable pages (`/`, `/llms.txt`, `/index.html.md`) |
+| `robots.txt` | `https://www.trstndvll.com/robots.txt` | Crawler directives; references the sitemap |
+
+When you add a new standalone page or change portfolio content, update `sitemap.xml` per [CLAUDE.md](CLAUDE.md). In-page section anchors (`#about`, etc.) are not separate sitemap entries.
 
 ---
 
@@ -77,3 +112,5 @@ To deploy updates:
    git push origin main
    ```
 3. Wait a minute or two for GitHub Pages to rebuild. Then refresh the live URL.
+
+If you changed portfolio copy or added/renamed sections, confirm `llms.txt`, `index.html.md`, and `sitemap.xml` (`<lastmod>`) were updated too. Add a new `<url>` entry when introducing a new crawlable page.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,10 +1,12 @@
 :root {
   --blue: #1a6bd6;
+  --blue-dark: #1558b0; /* WCAG AA fix — was: inline #1558b0 on .btn-submit:hover */
   --blue-light: #e8f0fc;
   --blue-mid: #c5d8f8;
   --dark: #111827;
   --mid: #374151;
   --muted: #6b7280;
+  --muted-on-dark: #9ca3af; /* WCAG AA fix — was: #6b7280 placeholder / #4b5563 footer */
   --border: #e5e9f0;
   --bg: #f7f9fc;
   --white: #ffffff;
@@ -244,7 +246,7 @@ section + section { border-top: 1px solid var(--border); }
   border-radius: 99px;
   border: 1.5px solid var(--blue-mid);
   background: var(--blue-light);
-  color: var(--blue);
+  color: var(--blue-dark); /* WCAG AA fix — was: var(--blue) */
   font-size: 0.82rem;
   font-weight: 600;
   transition: background 0.18s, border-color 0.18s;
@@ -317,7 +319,7 @@ section + section { border-top: 1px solid var(--border); }
   align-items: center;
   gap: 0.35rem;
   background: var(--blue-light);
-  color: var(--blue);
+  color: var(--blue-dark); /* WCAG AA fix — was: var(--blue) */
   border: 1px solid var(--blue-mid);
   border-radius: 99px;
   padding: 0.25rem 0.75rem;
@@ -547,7 +549,7 @@ details.case-study {
 .edu-card .badge {
   display: inline-block;
   background: var(--blue-light);
-  color: var(--blue);
+  color: var(--blue-dark); /* WCAG AA fix — was: var(--blue) */
   border: 1px solid var(--blue-mid);
   border-radius: 99px;
   font-size: 0.72rem;
@@ -638,9 +640,9 @@ details.case-study {
   transition: border-color 0.2s;
 }
 .form-row input::placeholder,
-.form-row textarea::placeholder { color: #6b7280; }
+.form-row textarea::placeholder { color: var(--muted-on-dark); /* WCAG AA fix — was: #6b7280 */ }
 .form-row input:focus,
-.form-row textarea:focus { border-color: var(--blue); }
+.form-row textarea:focus { border-color: var(--blue-mid); /* WCAG AA fix — was: var(--blue) */ }
 .form-row textarea { resize: vertical; min-height: 90px; }
 .form-recaptcha--hidden {
   display: none !important;
@@ -664,18 +666,37 @@ details.case-study {
   cursor: pointer;
   transition: background 0.18s;
 }
-.btn-submit:hover { background: #1558b0; }
+.btn-submit:hover { background: var(--blue-dark); /* WCAG AA fix — was: #1558b0 */ }
 .btn-submit:disabled {
   opacity: 0.7;
   cursor: not-allowed;
 }
-.footer-copy {
+.footer-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
   margin-top: 2.5rem;
   padding-top: 1.5rem;
   border-top: 1px solid #1f2937;
+}
+.footer-copy {
   font-size: 0.78rem;
-  color: #4b5563;
-  text-align: center;
+  color: var(--muted-on-dark); /* WCAG AA fix — was: #4b5563 */
+  text-align: left;
+}
+.footer-llm-link {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--muted-on-dark);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.footer-llm-link:hover { color: #fff; }
+.footer-llm-link:focus-visible {
+  outline: 2px solid var(--blue-mid);
+  outline-offset: 2px;
 }
 
 /* ── RESPONSIVE ── */

--- a/index.html
+++ b/index.html
@@ -668,8 +668,11 @@
       </div>
     </div>
 
-    <div class="footer-copy">
-      © <span id="copy-year"></span> Tristan Douville · Made in Canada 🇨🇦
+    <div class="footer-bar">
+      <div class="footer-copy">
+        © <span id="copy-year"></span> Tristan Douville · Made in Canada 🇨🇦
+      </div>
+      <a class="footer-llm-link" href="/llms.txt">LLM resources</a>
     </div>
   </div>
 </section>

--- a/index.html.md
+++ b/index.html.md
@@ -1,0 +1,411 @@
+# Tristan Douville — Senior Product Manager
+
+Product leader with 5+ years driving B2B SaaS from 0→1 launch through growth-stage scale. I work directly with executive leadership on strategy and I've built product functions from the ground up — hiring teams, designing operating models, and establishing processes that let development move fast. I also build LLM-powered workflows and AI product discovery tools.
+
+- [Email](mailto:trstndvll@gmail.com)
+- [GitHub](https://github.com/trstndvll)
+- [LinkedIn](https://linkedin.com/in/trstndvll)
+
+## About Me
+
+### My Background
+
+After studying computer science and technical writing I started my career in IT before transitioning into product management. My technical foundation means I can go deep with engineering teams while still keeping the user front-and-centre.
+
+### What I Enjoy
+
+I thrive building 0→1 products — taking ambiguous problems through discovery, defining the right scope, and shipping solutions that drive real customer value and user delight. I especially love being a translator between technical and non-technical teams.
+
+### What's Next
+
+I'm looking for a Senior PM or Lead PM role at a growth-stage small business or established organization where I can own a product area end-to-end, learn an entirely new domain, and upskill both technically and professionally.
+
+## Skills & Tools
+
+### Product Leadership
+
+- Agile, Kanban, & Scrum
+- AI Strategy
+- BI & Data Analysis
+- Competitor Analysis
+- Customer Interviews
+- Product Governance
+
+### Technical Skills
+
+- Data Modelling
+- HTML/CSS
+- Prompt Engineering
+- Python
+- SQL
+- SR&ED Reporting
+- TypeScript
+
+### Tools
+
+- Atlassian
+- AWS
+- Figma
+- GitHub
+- HotJar
+- Metabase
+- Mixpanel
+- Notion
+- Zapier
+
+### AI & Automation
+
+- ChatGPT
+- Claude
+- Cursor
+- Magic Patterns
+- MCP
+- n8n
+- OpenAI API
+- Vercel
+
+## Case Studies
+
+### Building a Product Function from Scratch
+
+Designed and shipped a full SDLC from the ground up; solo PM to 3-person team. 25% reduction in production bugs. Partnered with leadership to shift engineering to a startup mentality, laying foundations for a 0→1 platform launch.
+
+#### Context
+
+When I joined Pivott, there was **no product function** — no process, no team, and no defined way of taking work from idea to shipped. The engineering team was experienced and capable, but had come from a **stable, profitable business** where the primary mode was **maintenance and incremental improvement**. The mandate was to build a **brand-new SaaS product at startup pace**.
+
+#### Problem
+
+Launching a **0→1 product** without a product function isn't just a process gap — it's a **structural risk**. Without defined ownership, prioritization, and delivery workflows, teams default to **ad hoc decisions**, **unclear requirements**, and **reactive engineering**.
+
+**Core tension:** Move fast enough to build a competitive product while establishing the process rigor needed to sustain it.
+
+There was also a cultural challenge: the engineering team's instincts were calibrated for **stability, not speed**, and process change without credibility rarely sticks.
+
+#### My Role
+
+- **Assessed the full gap** between where the team was operating and what a startup delivery model required
+- **Designed a complete SDLC** spanning idea submission through to post-release review and success monitoring
+- Leveraged my **CSPO certification** to bring in proven agile frameworks and external perspectives on team rituals
+- **Built the business case** for dedicated product and QA hires
+- **Partnered directly with the CEO** to secure the backing needed to drive cultural change with the engineering team
+
+#### Key Decisions
+
+**1. Design the full lifecycle before hiring**
+
+Rather than hiring first and figuring out process later, I mapped the complete SDLC — **17 phases** from idea submission to review and success monitoring — before growing the team. This gave new hires a **functioning system from day one**.
+
+**2. Secure CEO alignment before rolling out to engineering**
+
+Given the cultural gap, I recognized that process changes needed to come with **executive weight** behind them. Getting the CEO aligned first meant the shift wasn't just a PM's opinion — it was **company direction**.
+
+**3. Use certification frameworks as a starting point, not a constraint**
+
+Applied **CSPO frameworks** (planning poker, sprint rituals, backlog governance) as a baseline, then adapted them to **Pivott's stage and team dynamics** rather than implementing them by the book.
+
+#### Execution
+
+- **Designed and documented a full SDLC** covering idea submission, prioritization, requirements, design, hand-off, development, testing, release, and post-launch review
+- **Hired and onboarded** a PM, a product designer, and a QA engineer — growing from a **solo PM to a 3-person product team**
+- **Established agile best practices** and team rituals from the ground up
+- Introduced **Jira-based defect tracking** to create a measurable quality baseline
+
+#### Outcome
+
+- **Fully operational product function** built in under **6 months**
+- **Production bugs reduced by 25%** following introduction of QA and formal acceptance testing
+- Engineering team successfully transitioned from **maintenance-mode** to **startup delivery cadence**
+- Operating model became the foundation for the **0→1 launch** of Pivott's core contract management platform
+- Established **scalable team and process infrastructure** that supported subsequent engineering growth from **5 to 8**
+
+### Protecting Velocity by Reducing Scope — Solving for the 95%
+
+Scoped an MVP that covered ~95% of real customer needs and shipped on time. Avoided a months-long engineering detour by anchoring decisions in usage data, not hypothetical edge cases.
+
+#### Context
+
+Leadership proposed a new feature to help customers manage **renewal terms** within **contract documents** — a known **pain point** for users managing **long-term agreements**.
+
+#### Problem
+
+Initial designs aimed to model **every possible renewal scenario** across all document types. While comprehensive, this approach introduced **significant technical complexity**, a **high cognitive load** for end users, and a timeline that would delay a **widely-requested feature**.
+
+**Core tension:** Deliver a complete solution vs. deliver a usable solution quickly.
+
+There was also internal misalignment — **leadership** favoured the more robust approach.
+
+#### My Role
+
+- **Analyzed** **session recordings** and **support tickets** to understand real user behaviour
+- Used **LLMs** to review **OCR'd contract text** and identify patterns in **renewal terms**
+- Found that the **majority of users** had **simple, repeatable renewal patterns**
+- **Facilitated discussions** with leadership to refocus on **core user needs**
+- **Managed stakeholder expectations** during a decision conflict
+
+#### Key Decisions
+
+**1. Reduce scope to match real usage**
+
+Prioritized a recurrence-based model covering the most common renewal scenarios. Avoided building for edge cases upfront.
+
+**2. Leverage known patterns**
+
+Drew from existing SaaS conventions and competitor solutions to reduce the user learning curve.
+
+**3. Position as an MVP**
+
+Framed the solution as a test of user demand, keeping the door open for expansion. This reduced resistance by aligning on iteration over perfection.
+
+#### Execution
+
+- Partnered with **engineering** to define a **lean, flexible recurrence system**
+- Kept scope tightly aligned to **core use cases**
+- Instrumented the feature with **Mixpanel** to measure **adoption** and **usage patterns**
+- Led **internal enablement** and **external rollout** through documentation and customer education
+
+#### Outcome
+
+- Feature launched successfully and **remains in active use**
+- Covered **~95%** of customer use cases, validating the **simplified approach**
+- Avoided **significant engineering investment** in low-frequency edge cases
+- The **"comprehensive" solution** was **deprioritized indefinitely**, freeing capacity for **higher-impact roadmap items**
+
+### Rebuilding a Marketing Website for Team Velocity
+
+Led a full marketing site rebuild using AI-native tooling; prototype in 1 week, launched in under 4 weeks. Enabled non-developer marketing contributions for the first time and reduced monthly tooling costs by ~40%.
+
+#### Context
+
+Pivott's marketing site was built on **Webflow** using a purchased template. Over time, the site's needs had grown well past what the platform handled well: the marketing team couldn't independently build new pages, custom interactions required developer involvement, and a planned **redesign** was quietly becoming harder to justify.
+
+Meanwhile, the product had real content needs. **New feature landing pages were stalled.** A long-requested pricing page redesign — with collapsible comparison tables and an interactive plan structure — had been deferred repeatedly because the effort in Webflow made it not worth prioritizing.
+
+#### Problem
+
+The root issue wasn't design quality — it was a **platform mismatch**. Webflow's visual editor handled basic copy changes, but broke down for anything structural. Adding a new component, building an interactive pricing layout, or launching a feature landing page each required either a developer or a Webflow specialist. Pivott had neither available for marketing work at this time.
+
+**Core tension:** The marketing site needed to grow with the product, but every meaningful change was a project in its own right.
+
+There was also a compounding risk: Webflow was retiring its **legacy editor**, forcing a workflow transition regardless — making the status quo a temporary solution at best.
+
+#### My Role
+
+- **Identified the constraint proactively** before it became a blocker and built a concrete alternative before bringing it to leadership
+- **Built the business case** comparing Webflow and a React/Vercel stack across cost, capability, and long-term flexibility
+- **Led the full technical implementation** — repo setup, design system, component architecture, and deployment pipeline
+- **Established the AI-native design and build workflow** using Magic Patterns, Claude Code, and Cursor
+- **Designed the project plan** including content audit, infrastructure checklist, and DNS migration process
+- **Presented the prototype** to the CEO and Head of Sales and secured approval to move the 2027 redesign to 2026
+
+#### Key Decisions
+
+**1. Accelerate the 2027 redesign by over a year**
+
+The effort required to build a competent Webflow site was roughly equivalent to building in React — but with worse long-term outcomes. Framed this clearly for leadership and got the go-ahead to move immediately, collapsing a year-plus timeline into weeks.
+
+**2. Use Magic Patterns as the primary design tool**
+
+Rather than hiring a designer or Webflow consultant, used Magic Patterns to produce a fully on-brand React prototype — complete component library, brand token system, responsive behaviour, and accessibility compliance — before any production code was written. This gave leadership a concrete, clickable prototype to approve before committing engineering resources.
+
+**3. Choose Next.js over a simpler Vite + React Router setup**
+
+Evaluated both options and chose Next.js for its server-side rendering (direct SEO benefit for a marketing site), file-based routing, and native metadata handling. Vercel's first-class support made deployment, staging branches, and preview URLs essentially zero-config.
+
+**4. Design for non-developer contribution from day one**
+
+The explicit goal was a codebase that a Marketing Manager could actively contribute to — not just review. Chose a named Tailwind token system, a clear folder structure, and wrote a **CLAUDE.md** conventions file so Claude Code and Cursor could produce codebase-consistent output without manual correction. Copy updates, new pages, and image swaps no longer require a developer.
+
+#### Execution
+
+- Ran **60+ iterations in Magic Patterns** to produce a complete, approved design system covering **10+ page templates** and a full reusable component library — homepage, pricing, sign-up, feature template, About, Contact, Integrations, Terms, and a brand reference page
+- **Set up full production infrastructure**: Next.js 15 repo, Vercel hosting with staging and production branch strategy, Vercel Blob for asset storage, and Formspree for form handling with spam filtering and Zapier workflows
+- **Wrote CLAUDE.md** — a conventions document covering Tailwind tokens, component patterns, routing, image handling, and SEO conventions, enabling Claude Code and Cursor to contribute consistently without rework
+- **Generated 17+ pages** using a combination of Magic Patterns exports, Claude Code, and Cursor with structured CSV-driven content inputs for batch feature page generation
+- Established a repeatable **design-to-production pipeline**: brief in Magic Patterns → export TSX → integrate → Vercel auto-deploys a preview URL for review
+- Produced a full **project plan and task breakdown** — including content audit, infrastructure setup, third-party tool migration checklist, and DNS cutover process — for cross-functional execution
+
+#### Outcome
+
+- **Full marketing site redesigned and launched in under 4 weeks** — compared to a planned 12+ month timeline under the original 2027 approach
+- **Non-developer contribution enabled for the first time**: Marketing Manager can draft pages in Magic Patterns, push content updates via Claude Code, and review changes on Vercel preview URLs without engineering involvement
+- **Two high-priority product launches unblocked** — previously stalled on the old platform, built and ready for content at launch
+- **All future pages follow a consistent, templated system** — new feature pages are a content swap, not a new project
+- **~40% reduction in monthly tooling costs** compared to Webflow site plan and workspace seat fees
+
+### Eliminating Team Bottlenecks — A Scalable, Internal AI Knowledge System
+
+Built an internal AI assistant now handling hundreds of support queries per month. Eliminated a recurring bottleneck for the product team without adding headcount or process overhead.
+
+#### Context
+
+The product team was increasingly pulled into **customer support** — fielding interruptions via **Slack**, **email**, and calls to help resolve tickets. **Comprehensive documentation**, **PRDs**, and **BI tools** existed but were **underutilized** by the **Customer Success (CS) team**.
+
+#### Problem
+
+Support staff relied on the **product team** for answers instead of **self-serving** through available resources, causing:
+
+- **Constant interruptions** to product work and roadmap execution
+- **Slower response times** due to dependency on **PM availability**
+- **Underutilization** of existing documentation
+
+**Core tension:** How do you enable support to independently access product knowledge without making the product team a bottleneck?
+
+#### My Role
+
+- Owned **internal documentation strategy** as part of the product team
+- **Interviewed CS team members** to understand their **real-time support workflows**
+- Identified that the issue wasn't lack of documentation — it was lack of **accessibility** and **synthesis**
+- Explored solutions ranging from **process improvements** to **tooling**
+
+#### Key Decisions
+
+**1. Validate non-technical solutions first**
+
+Improved internal documentation and ran a lunch & learn on effective self-serve questioning techniques (adapting PM-style user interviewing for support). Helpful, but did not reduce reliance on the product team.
+
+**2. Invest in a scalable system**
+
+Identified an opportunity to use AI to aggregate and synthesize internal knowledge. Proposed an internal "Product Concierge" to enable real-time, self-serve answers.
+
+**3. Prioritize trust and accuracy over breadth**
+
+Designed the system with strict guardrails: surfacing source references, indicating the age of information, and limiting responses when confidence was low.
+
+#### Execution
+
+- Defined requirements and architecture for a **Slack-based AI assistant** connected to **internal documentation**, **PRDs**, **code repositories**, and select **BI queries**
+- Collaborated with **developers** to validate the approach and ensure **feasibility**
+- **Built and iterated** on the solution, refining **prompts** and **data connections**
+- Implemented **tracking** to monitor **usage** and **response quality**
+
+#### Outcome
+
+- **"Product Concierge"** is now actively used, handling **hundreds of internal queries per month**
+- Reduced **direct interruptions** to the product team
+- Improved **speed** and **consistency** of support responses
+- Created a **scalable knowledge system**, reducing dependency on **individual team members**
+- Established a foundation for **future internal AI tooling**
+
+### Converting a High-Value Client Problem into a 20% Revenue Lift & Reusable Platform
+
+Turned a high-value client pain point into a 20% YoY revenue increase. Delivered a configurable workflow platform on a deadline; unlocked additional expansion within the same account.
+
+#### Context
+
+A **high-value client** relied on **email** and **spreadsheets** for a **critical financial workflow** and experienced delays in their **year-end reconciliation** due to **missing records**. They came to our product and leadership team with a request to build a **proper solution**.
+
+#### Problem
+
+The client required a **highly customized workflow** our product didn't support. Key challenges included:
+
+- A **time-sensitive deadline** tied to their **fiscal year-end**
+- **Conflicting requirements** across **multiple client departments**
+- **One-off solution risk** — potential roadmap diversion without clear **reuse potential**
+
+**Core tension:** Solve a critical client problem quickly without introducing long-term product bloat.
+
+#### My Role
+
+- **Led user interviews** with client stakeholders to uncover **root workflow issues**
+- **Synthesized findings** into clear **product opportunities** for leadership
+- Owned the **PRD** and **solution design**, including a **functional prototype**
+- Liaised with **Customer Success** and **Engineering** to ensure alignment
+- Acted as the bridge between **client needs**, **business goals**, and **technical feasibility**
+
+#### Key Decisions
+
+**1. Build vs. defer**
+
+- Option A: Defer to protect the roadmap
+- Option B: Build a one-off solution
+- **Option C (chosen): Build an MVP with a scalable architecture**
+
+**2. MVP scope definition**
+
+Prioritized only the core workflow blockers for year-end readiness. Deferred edge cases to post-launch iterations.
+
+**3. Platform investment**
+
+Designed the solution to support configurable workflows (fields, statuses, naming), with clear potential for reuse across other clients.
+
+#### Execution
+
+- Aligned **internal stakeholders** on **scope vs. timeline** tradeoffs
+- Collaborated with **engineering** to define a **flexible technical design** under **time constraints**
+- Presented a **client-facing proposal** including problem framing, a **prototype walkthrough**, a **delivery plan**, and a **pricing and support model**
+
+#### Outcome
+
+- Client accepted the proposal, increasing spend by **20% YoY**
+- Delivered **on time** for **fiscal year-end**
+- Established a foundation for **configurable workflows**, enabling **reuse across other clients**
+- Project success generated an **internal referral**, expanding into **additional opportunities** within the client's organization
+
+## Recent Work Experience
+
+### Senior Product Manager — Pivott Software
+
+[Pivott Software](https://pivott.io) · Victoria, BC · May 2025 – Present
+
+3-person product team, 8 developers
+
+- **Built and deployed agentic AI workflows** for automated data extraction, reducing manual processing time and enabling quick time-to-value.
+- **Collaborated directly with the CEO** to define product vision, translate business strategy into a prioritized roadmap, and identify new revenue opportunities.
+- **Designed a formal product–design–engineering operating model**, including hiring and onboarding a 3-person product team, establishing department processes, and managing professional development.
+- **Scaled the engineering team from 5 to 8** by hiring and onboarding 3 developers and a QA engineer, establishing agile best practices and team rituals from the ground up.
+
+### Product Manager — Pivott Software
+
+[Pivott Software](https://pivott.io) · Victoria, BC · Jan 2024 – May 2025
+
+Team of 8 developers
+
+- **Led 0→1 launch of a contract management SaaS platform** from market analysis and ideation through to revenue in under a year.
+- **Designed and executed a product-led growth (PLG) strategy** including freemium tiers, self-serve onboarding, and TTV optimizations, resulting in free-to-paid customer conversions.
+- **Implemented a sandbox environment and sign-up workflow** to demonstrate features to new users and convert them to freemium or paid.
+- **Ran go-to-market launches** alongside marketing; tracked feature adoption and release cadence weekly.
+
+### Product Manager — PostEngine
+
+[PostEngine](https://postengine.com) · Victoria, BC · April 2021 – Dec 2023
+
+Team of 6 developers
+
+- **Served as product owner and SME for PostEngine**, a B2B SaaS marketing automation platform. Owned roadmap and stakeholder relationships.
+- **Spearheaded 0→1 launch of multiple features**, applying MVP principles to reduce time-to-market and validate value hypotheses.
+- **Led agile delivery for a team of 6 developers**; conducted backlog refinement, sprint planning, estimation, and retrospectives.
+- **Established OKR & KPI reporting** for the product team, including story point velocity, project budget tracking, and release cadence.
+
+## Volunteering
+
+### Mentor — PM Mentorship Program
+
+[ProductBC](https://productbc.ca/) · Vancouver, BC · September 2024 – Present
+
+- **Mentored 3 product managers** across separate 6-month engagements, ranging in roles from Associate PM to PM through hands-on support and career coaching.
+- **Held bi-weekly 1:1s** focused on real-world product challenges, team dynamics, and the day-to-day realities of working in product.
+- **Fostered a space for honest, practical conversation** — balancing structured feedback with genuine camaraderie and peer support.
+
+## Education & Certifications
+
+### Bachelor of Science — Computer Science
+
+Faculty of Engineering, [University of Victoria](https://uvic.ca) · September 2014 – August 2019
+
+### Certified Scrum Product Owner (CSPO)
+
+Scrum Alliance · Credential ID 001394694 · July 2022
+
+## Contact
+
+Open to opportunities. If you're building something interesting, I'd love to be a part of it. Reach out to me at the links below.
+
+- [trstndvll@gmail.com](mailto:trstndvll@gmail.com)
+- [linkedin.com/in/trstndvll](https://linkedin.com/in/trstndvll)
+
+Contact form available on the live site at [trstndvll.com/#contact](https://www.trstndvll.com/#contact).
+
+---
+
+© Tristan Douville · Made in Canada 🇨🇦 · [LLM resources](/llms.txt)

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,71 @@
+# Tristan Douville
+
+> Senior Product Manager with 5+ years driving B2B SaaS from 0→1 launch through growth-stage scale. Background in computer science and technical writing. Based in Victoria, BC, Canada. Builds LLM-powered workflows and AI product discovery tools. Open to Senior PM or Lead PM roles at growth-stage or established organizations.
+
+Tristan Douville is a product leader who works directly with executive leadership on strategy and has built product functions from the ground up — hiring teams, designing operating models, and establishing delivery processes. His technical foundation lets him go deep with engineering while keeping users front-and-centre.
+
+**Current role:** Senior Product Manager at [Pivott Software](https://pivott.io) (May 2025–present), leading a 3-person product team with 8 developers.
+
+**Career focus:** 0→1 products, executive collaboration, cross-functional outcomes, measurable business results. Thrives as a translator between technical and non-technical teams.
+
+**Looking for:** End-to-end product ownership in a new domain at a growth-stage small business or established organization.
+
+**Contact:** trstndvll@gmail.com · [LinkedIn](https://linkedin.com/in/trstndvll) · [GitHub](https://github.com/trstndvll)
+
+### Skills (summary)
+
+- **Product leadership:** Agile/Kanban/Scrum, AI strategy, BI & data analysis, competitor analysis, customer interviews, product governance
+- **Technical:** Python, SQL, TypeScript, HTML/CSS, data modelling, prompt engineering, SR&ED reporting
+- **Tools:** Atlassian, AWS, Figma, GitHub, HotJar, Metabase, Mixpanel, Notion, Zapier
+- **AI & automation:** ChatGPT, Claude, Cursor, MCP, n8n, OpenAI API, Magic Patterns, Vercel
+
+### Experience (summary)
+
+| Role | Company | Dates |
+|------|---------|-------|
+| Senior Product Manager | Pivott Software | May 2025 – Present |
+| Product Manager | Pivott Software | Jan 2024 – May 2025 |
+| Product Manager | PostEngine | Apr 2021 – Dec 2023 |
+
+**Pivott highlights:** Built product function from scratch; 0→1 contract management SaaS launch; PLG strategy with freemium tiers; agentic AI workflows; scaled engineering 5→8.
+
+**PostEngine highlights:** Product owner for B2B marketing automation SaaS; multiple 0→1 feature launches; agile delivery for 6 developers; OKR/KPI reporting.
+
+**Volunteering:** Mentor, ProductBC PM Mentorship Program (Sep 2024–present) — 3 mentees across 6-month engagements.
+
+**Education:** BSc Computer Science, University of Victoria (2014–2019). Certified Scrum Product Owner (CSPO), Scrum Alliance (2022).
+
+### Case studies (summary)
+
+1. **Building a Product Function from Scratch** — Designed full SDLC (17 phases); grew solo PM to 3-person team; 25% reduction in production bugs; enabled 0→1 platform launch at Pivott.
+2. **Protecting Velocity by Reducing Scope** — Scoped renewal-terms MVP to ~95% of real usage using session recordings, support tickets, and LLM analysis of OCR'd contracts; shipped on time; comprehensive approach deprioritized.
+3. **Rebuilding a Marketing Website for Team Velocity** — Led Webflow → Next.js/Vercel rebuild with AI-native tooling (Magic Patterns, Claude Code, Cursor); prototype in 1 week, launched in under 4 weeks; ~40% tooling cost reduction; enabled non-developer marketing contributions.
+4. **Internal AI Knowledge System ("Product Concierge")** — Slack-based assistant synthesizing docs, PRDs, repos, and BI; handles hundreds of internal queries/month; reduced product team interruptions.
+5. **High-Value Client → 20% Revenue Lift** — Turned client workflow pain point into configurable platform MVP; delivered on fiscal year-end deadline; 20% YoY spend increase; unlocked expansion within account.
+
+## Full site content
+
+- [Portfolio (markdown)](https://www.trstndvll.com/index.html.md): Complete markdown version of the single-page portfolio — case studies, experience, skills, education, and contact
+
+## Site sections
+
+- [About](https://www.trstndvll.com/#about): Background, what I enjoy, what I'm looking for
+- [Skills & Tools](https://www.trstndvll.com/#skills): Product leadership, technical skills, tools, AI & automation
+- [Case Studies](https://www.trstndvll.com/#case-studies): Five expandable case studies with Context → Outcome structure
+- [Experience](https://www.trstndvll.com/#experience): Pivott and PostEngine roles with bullet highlights
+- [Volunteering](https://www.trstndvll.com/#volunteering): ProductBC mentorship
+- [Education](https://www.trstndvll.com/#education): UVic BSc CS, CSPO certification
+- [Contact](https://www.trstndvll.com/#contact): Email, LinkedIn, contact form
+
+## Profiles
+
+- [LinkedIn](https://linkedin.com/in/trstndvll): Professional profile
+- [GitHub](https://github.com/trstndvll): Code and projects
+- [Email](mailto:trstndvll@gmail.com): trstndvll@gmail.com
+
+## Optional
+
+- [Pivott Software](https://pivott.io): Current employer — contract management SaaS
+- [PostEngine](https://postengine.com): Former employer — B2B marketing automation
+- [ProductBC](https://productbc.ca/): PM mentorship program (Vancouver, BC)
+- [University of Victoria](https://uvic.ca): BSc Computer Science alma mater

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.trstndvll.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.trstndvll.com/</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.trstndvll.com/llms.txt</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.trstndvll.com/index.html.md</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Add LLM-readable content, AI agent conventions, and SEO discovery files so the portfolio is easier for crawlers and coding assistants to use.

- Add llms.txt (curated summary) and index.html.md (full markdown mirror of index.html)
- Add CLAUDE.md as the canonical rulebook and .cursor/rules/canonical-rules.mdc for Cursor Agent
- Add sitemap.xml and robots.txt listing /, /llms.txt, and /index.html.md
- Link to /llms.txt from the contact footer (“LLM resources”) with a two-column footer layout
- Fix WCAG AA contrast: introduce --blue-dark and --muted-on-dark tokens; apply to badges, form placeholders, focus borders, and footer text
- Document agent resources, LLM file sync, and sitemap upkeep in README.md