### PR TITLE
Add floating nav bar on scroll | Sync README and CLAUDE with current site

### DIFF
--- a/.cursor/rules/canonical-rules.mdc
+++ b/.cursor/rules/canonical-rules.mdc
@@ -11,5 +11,6 @@ Before editing code or content:
 1. Read @CLAUDE.md if it is not already in context
 2. Follow its rules — especially WCAG AA, coding conventions, and keeping `index.html.md` / `llms.txt` in sync with `index.html`
 3. Treat [README.md](README.md) as human onboarding only; do not treat it as overriding CLAUDE.md
+4. When a change may affect project docs, outline required README/CLAUDE updates and **ask for permission** before editing them — see CLAUDE.md § Documentation maintenance
 
 When guidance conflicts, **CLAUDE.md wins**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ Personal PM portfolio — single-page static site hosted on GitHub Pages at `htt
 | `sitemap.xml` | XML sitemap for search engines — served at `/sitemap.xml`; lists all crawlable URLs |
 | `robots.txt` | Crawler directives — served at `/robots.txt`; points to `sitemap.xml` |
 | `CNAME` | Custom domain (`www.trstndvll.com`) |
+| `404.html` | GitHub Pages custom 404 — `noindex`, reuses `css/styles.css` |
 | `README.md` | Human-facing intro, local dev, deployment |
+| `.cursor/rules/` | Cursor always-applied rules — points agents at CLAUDE.md |
 | `.gitignore` | Ignores `.DS_Store` |
 | `resume/index.html` | Self-contained print resume — own `<style>` block, same design tokens, exports to PDF via Chrome print |
 
@@ -57,7 +59,9 @@ Personal PM portfolio — single-page static site hosted on GitHub Pages at `htt
 - Interactive controls: `aria-label`, `aria-expanded`, `aria-live`
 - Content images: meaningful `alt` text; decorative tool icons: `alt=""`
 - Form reCAPTCHA hidden until fields filled; `aria-hidden` toggled with visibility
+- Active nav link: `.is-active` + `aria-current="location"` (desktop scroll-spy)
 - `scroll-margin-top: 56px` on sections so anchor nav doesn't hide headings
+- `prefers-reduced-motion` respected for nav and card transitions
 
 **Keyboard**
 - Hamburger menu, form submit, and `<details>` case-study summaries must work without a mouse
@@ -85,13 +89,21 @@ Personal PM portfolio — single-page static site hosted on GitHub Pages at `htt
 - Class naming: kebab-case; BEM-style modifiers (`form-recaptcha--hidden`)
 - Card pattern: white bg, `border: 1px solid var(--border)`, `border-radius: var(--radius)`
 - Typography: DM Sans (body/UI), DM Serif Display (hero, contact, case study titles)
-- Responsive breakpoints: `1024px` (nav → hamburger), `640px` (grid collapse)
+- Responsive breakpoints:
+  - `1100px` — tighten desktop nav link gap before hamburger switch
+  - `1025px` — desktop-only floating nav width + scroll-spy media query
+  - `1024px` — nav → hamburger
+  - `640px` — grid collapse
+- Floating nav: `.nav-wrapper--floating` modifier toggled on scroll; `prefers-reduced-motion: reduce` disables nav transitions
 
 ### JavaScript
 
-- Inline `<script>` at bottom of `index.html` — no separate JS file today
-- DOM queries by ID, event listeners, async `fetch` to Formspree
-- reCAPTCHA shown only after all form fields filled (`updateRecaptchaVisibility`)
+- Inline `<script>` at bottom of `index.html` — no separate JS file today (~160 lines)
+- Dynamic copyright year in footer
+- Floating nav toggle on scroll (`requestAnimationFrame`-throttled)
+- Hamburger menu toggle + close on link click
+- Desktop scroll-spy active nav (`.is-active` class, `aria-current="location"`, breakpoint `1025px`)
+- Contact form: conditional reCAPTCHA visibility (`updateRecaptchaVisibility`), async `fetch` to Formspree, `aria-live` status feedback
 
 ### Assets
 
@@ -150,6 +162,7 @@ See [README.md](README.md) for step-by-step local dev and deployment instruction
 - When editing portfolio copy or structure in `index.html`, update `index.html.md` and `llms.txt` in the same pass — do not leave them stale
 - After any content/structure edit: spot-check `llms.txt` and `index.html.md` reflect the same facts and section anchors as `index.html`
 - When adding a new crawlable page or materially updating an existing one, update `sitemap.xml` (`<lastmod>` at minimum; new `<url>` entry for new pages)
+- When a change may affect project docs, include a **Documentation impact** note (see § Documentation maintenance) and ask before editing README/CLAUDE
 
 ### Never
 
@@ -160,6 +173,20 @@ See [README.md](README.md) for step-by-step local dev and deployment instruction
 - Commit secrets that aren't already public client-side keys
 - Create commits or push unless explicitly asked
 - Duplicate README content into this file
+- Update `README.md` or `CLAUDE.md` without explicit user permission (except when the task explicitly includes doc updates)
+
+### Documentation maintenance
+
+When making changes to site code, content, structure, conventions, or agent workflow:
+
+1. **Do not silently edit** `README.md` or `CLAUDE.md` unless the user explicitly requested doc updates in the same task.
+2. **Before finishing** (agent mode) or **in every plan** (plan mode), include a **Documentation impact** subsection when applicable, listing:
+   - Which sections of `README.md` and/or `CLAUDE.md` may need updating
+   - Why (e.g. new JS behaviour, new file, convention change)
+3. **Ask the user for permission** before making those doc edits.
+4. **Exception:** when the task explicitly includes updating these files, proceed without a separate ask.
+
+This rule applies only to `README.md` and `CLAUDE.md`. LLM file sync (`index.html.md`, `llms.txt`) and sitemap updates follow the existing automatic rules above.
 
 ### When editing content
 
@@ -187,9 +214,16 @@ Not yet enforced — review and accept/reject before treating as canonical.
 - **[SUGGESTED] Commit messages:** Imperative, sentence-case (e.g. `Add volunteer section`, `Fix case study mobile padding`). Avoid kebab-case (`update-hero`).
 - **[SUGGESTED] External links:** Always add `rel="noopener noreferrer"` on `target="_blank"` links (currently inconsistent).
 - **[SUGGESTED] Image paths:** Standardize on relative `images/…` for portability; reserve absolute URLs for OG/Twitter meta only.
-- **[SUGGESTED] JS extraction:** If JS grows beyond ~80 lines, move to `js/main.js` — not needed today.
-- **[SUGGESTED] Pre-deploy checklist:** Nav (desktop + mobile), case study expand/collapse, contact form + reCAPTCHA, responsive at 640px/1024px, **WCAG AA contrast spot-check** on any changed colours (browser DevTools or [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)).
+- **[SUGGESTED] JS extraction:** Inline JS is ~160 lines today; consider moving to `js/main.js` if it grows further.
+- **[SUGGESTED] Pre-deploy checklist:** Nav (desktop + mobile), floating nav on scroll, scroll-spy active states at 1025px+, case study expand/collapse, contact form + reCAPTCHA, responsive at 640px/1024px, **WCAG AA contrast spot-check** on any changed colours (browser DevTools or [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)).
 - **[SUGGESTED] Tooling:** Do not add ESLint/Prettier/CI unless the project grows significantly.
+
+## 404 page (`404.html`)
+
+- GitHub Pages serves this automatically for missing URLs
+- Reuses shared stylesheet (`css/styles.css`); minimal nav (brand link to `/` only)
+- `noindex` — do not add to sitemap or LLM files
+- Styles live in `css/styles.css` `/* ── 404 PAGE ── */` block
 
 ## Resume page (`resume/index.html`)
 
@@ -197,7 +231,8 @@ Not yet enforced — review and accept/reject before treating as canonical.
 - Uses the same CSS custom properties as the main site (copy values from `:root` in `css/styles.css` if tokens change)
 - Designed to fit on a single US Letter page when printed from Chrome
 - `resume/*.pdf` is gitignored — never commit built PDFs
-- Do not link from main site nav, sitemap.xml, llms.txt, or index.html.md
+- **Do link** from hero `.hero-links` (`href="resume/"`) — intentional, for visitors
+- **Do not link** from `.nav-links` / `.mobile-menu`, `sitemap.xml`, `llms.txt`, or `index.html.md`
 - When updating resume content, only edit `resume/index.html` — no LLM file sync required for this page
 - To verify layout: open in Chrome, Cmd+P, check "Save as PDF" preview shows single page with no clipping
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Tristan Douville — Product Manager Portfolio
 
-This repository contains the source for my personal portfolio site, hosted via **GitHub Pages** at `https://trstndvll.github.io`.  
+This repository contains the source for my personal portfolio site, hosted via **GitHub Pages** at `https://trstndvll.github.io` and `https://www.trstndvll.com` (custom domain via [`CNAME`](CNAME)).
 
 ---
 
@@ -12,7 +12,10 @@ The site is a single-page, responsive marketing-style page built with:
 - **CSS3** for layout and visual design (no framework)
 - A small amount of **vanilla JavaScript** for:
   - Mobile navigation (hamburger menu)
+  - Floating nav bar on scroll
+  - Desktop active-section highlighting in nav
   - Dynamically setting the current year in the footer
+  - Contact form submission via Formspree (with conditional reCAPTCHA)
 
 The layout is optimized for readability on both desktop and mobile and is intended to be fast-loading and easy to maintain.
 
@@ -41,8 +44,10 @@ Use CLAUDE.md when working with Claude Code or any AI assistant editing this cod
 - **Contact form**:
   - [Formspree](https://formspree.io/) — form submissions are sent via POST to Formspree; you receive and manage them in the Formspree dashboard.
   - [reCAPTCHA v2](https://www.google.com/recaptcha/about/) — "I'm not a robot" checkbox to reduce spam.
+- **Analytics**:
+  - [Google Analytics](https://analytics.google.com/) (gtag) — page view tracking.
 - **Hosting**:
-  - [GitHub Pages](https://pages.github.com/) from the `trstndvll.github.io` repository.
+  - [GitHub Pages](https://pages.github.com/) from the `trstndvll.github.io` repository, with custom domain `www.trstndvll.com`.
 
 ---
 
@@ -65,6 +70,7 @@ This site follows the [llms.txt](https://llmstxt.org/) convention for LLM-readab
 |------|-----|---------|
 | `sitemap.xml` | `https://www.trstndvll.com/sitemap.xml` | XML sitemap — lists all crawlable pages (`/`, `/llms.txt`, `/index.html.md`) |
 | `robots.txt` | `https://www.trstndvll.com/robots.txt` | Crawler directives; references the sitemap |
+| `404.html` | (served for missing URLs) | Custom GitHub Pages error page — styled consistently, `noindex`, not in the sitemap |
 
 When you add a new standalone page or change portfolio content, update `sitemap.xml` per [CLAUDE.md](CLAUDE.md). In-page section anchors (`#about`, etc.) are not separate sitemap entries.
 
@@ -99,6 +105,7 @@ This avoids any cross-origin quirks and more closely matches how GitHub Pages wi
 Because this repository is named `trstndvll.github.io`, GitHub automatically serves the content from the **default branch** (typically `main`) at:
 
 - `https://trstndvll.github.io`
+- `https://www.trstndvll.com` (custom domain via [`CNAME`](CNAME))
 
 To deploy updates:
 
@@ -120,6 +127,8 @@ If you changed portfolio copy or added/renamed sections, confirm `llms.txt`, `in
 ### Resume
 
 A print-ready resume page lives at `resume/index.html`. It uses the same design tokens as the main site and is intended to be opened in Chrome and saved as PDF via Cmd+P → Save as PDF.
+
+The resume is linked from the hero section (`resume/`) but is intentionally excluded from nav, sitemap, and LLM files.
 
 PDFs are excluded from version control via `.gitignore` (`resume/*.pdf`). Distribute the PDF directly — do not host it publicly.
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -34,16 +34,35 @@ a:hover { text-decoration: underline; }
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: padding 0.5s ease;
 }
 nav {
   background: rgba(255,255,255,0.95);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--border);
+  border: 1px solid transparent;
+  border-bottom-color: var(--border);
+  border-radius: 0;
+  box-shadow: none;
   padding: 0 2rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
   height: 56px;
+  transition: border-color 0.5s ease, border-radius 0.5s ease, box-shadow 0.5s ease;
+}
+.nav-wrapper--floating {
+  padding: 0.75rem 1.5rem 0;
+}
+.nav-wrapper--floating nav {
+  border-color: var(--blue-mid);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.07);
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-wrapper,
+  nav {
+    transition: none;
+  }
 }
 .nav-brand {
   font-weight: 700;
@@ -137,6 +156,17 @@ nav {
 }
 .mobile-menu a:last-child { border-bottom: none; }
 .mobile-menu a:hover { color: var(--blue); text-decoration: none; }
+.nav-wrapper--floating .mobile-menu {
+  top: calc(56px + 0.75rem);
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+  width: calc(100% - 3rem);
+  max-width: calc(860px - 3rem);
+  border: 1px solid var(--blue-mid);
+  border-bottom: 1px solid var(--blue-mid);
+  border-radius: var(--radius);
+}
 
 /* ── LAYOUT ── */
 .container {
@@ -832,12 +862,28 @@ details.case-study {
 
 /* ── RESPONSIVE ── */
 /* Nav: switch to hamburger before inline links wrap (icons widen the bar) */
+@media (min-width: 1025px) {
+  .nav-wrapper--floating nav {
+    width: fit-content;
+    max-width: calc(100% - 3rem);
+    margin-inline: auto;
+    gap: 2.5rem;
+  }
+}
 @media (max-width: 1100px) and (min-width: 1025px) {
   .nav-links { gap: 1.25rem; }
 }
 @media (max-width: 1024px) {
   .nav-links { display: none; }
   .hamburger { display: flex; }
+  .nav-wrapper--floating {
+    padding: 0.75rem 0 0;
+  }
+  .nav-wrapper--floating nav {
+    width: calc(100% - 3rem);
+    max-width: calc(860px - 3rem);
+    margin-inline: auto;
+  }
 }
 
 @media (max-width: 640px) {

--- a/index.html
+++ b/index.html
@@ -686,6 +686,26 @@
   // Dynamic copyright year
   document.getElementById('copy-year').textContent = new Date().getFullYear();
 
+  // Floating nav on scroll
+  const navWrapper = document.querySelector('.nav-wrapper');
+  const FLOAT_THRESHOLD = 8;
+  let navFloatScheduled = false;
+
+  function updateNavFloat() {
+    navFloatScheduled = false;
+    navWrapper.classList.toggle('nav-wrapper--floating', window.scrollY >= FLOAT_THRESHOLD);
+  }
+
+  function scheduleNavFloatUpdate() {
+    if (!navFloatScheduled) {
+      navFloatScheduled = true;
+      requestAnimationFrame(updateNavFloat);
+    }
+  }
+
+  window.addEventListener('scroll', scheduleNavFloatUpdate, { passive: true });
+  scheduleNavFloatUpdate();
+
   // Hamburger menu toggle
   const hamburger = document.getElementById('hamburger');
   const mobileMenu = document.getElementById('mobile-menu');


### PR DESCRIPTION
Toggle nav-wrapper--floating after scroll with rAF-throttled updates. Style floating state for desktop and mobile, including reduced-motion and hamburger menu positioning.

Update project docs to reflect floating nav, scroll-spy, Formspree, GA, custom domain, 404 page, and resume linking policy. Add Documentation maintenance rule requiring agents to outline and ask before editing README or CLAUDE.